### PR TITLE
Update hydroweight_attributes.R

### DIFF
--- a/R/hydroweight_attributes.R
+++ b/R/hydroweight_attributes.R
@@ -69,7 +69,9 @@ hydroweight_attributes <- function(loi = NULL,
       loi_r <- lapply(loi_columns, function(x) {
         loi_return <- fasterize::fasterize(loi,
           raster = distance_weights[[1]],
-          field = x
+          field = x,
+          ### Need to add background = 0 here, or else the averaging that happens later gets messed up with the NA's being removed for numeric values
+          background = 0
         )
       })
       names(loi_r) <- loi_columns


### PR DESCRIPTION
Found an issue where when you are hydroweighting non-categorical polygons, your numeric estimates are innacurate if you only have partial coverage of the area of interest. Suggest including background = 0 for these instances so that the averaging reflects the zeros in the dataset.